### PR TITLE
Fix file name sanitization

### DIFF
--- a/migration/cleanname.go
+++ b/migration/cleanname.go
@@ -10,7 +10,7 @@ import (
 // FileName returns sanitized filename without path delimiters
 func (op *Payload_OtpParameters) FileName() string {
 	return strings.Map(func(r rune) rune {
-		if r == filepath.Separator {
+		if r == filepath.Separator || r == filepath.PathListSeparator {
 			return '_'
 		}
 		return r


### PR DESCRIPTION
If an OTP name contains the PathListSeparator (':' on Windows), QR code file generation fails and a 0-byte file is written.

I am not a go developer and don't have a go dev environment set up, so apologies that this PR was drafted in the github online editor.