### PR TITLE
add migration artifact to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+migration.bin


### PR DESCRIPTION
prevents accidental uploading of migration.bin files that are created when used